### PR TITLE
Added support for python mysql-connector

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -17,6 +17,7 @@ urlparse.uses_netloc.append('postgis')
 urlparse.uses_netloc.append('mysql')
 urlparse.uses_netloc.append('mysql2')
 urlparse.uses_netloc.append('mysqlgis')
+urlparse.uses_netloc.append('mysql-connector')
 urlparse.uses_netloc.append('spatialite')
 urlparse.uses_netloc.append('sqlite')
 
@@ -30,6 +31,7 @@ SCHEMES = {
     'mysql': 'django.db.backends.mysql',
     'mysql2': 'django.db.backends.mysql',
     'mysqlgis': 'django.contrib.gis.db.backends.mysql',
+    'mysql-connector': 'mysql.connector.django',
     'spatialite': 'django.contrib.gis.db.backends.spatialite',
     'sqlite': 'django.db.backends.sqlite3',
 }

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -45,6 +45,17 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 5431
 
+    def test_mysql_connector_parsing(self):
+        url = 'mysql-connector://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'mysql.connector.django'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == 5431
+
     def test_cleardb_parsing(self):
         url = 'mysql://bea6eb025ca0d8:69772142@us-cdbr-east.cleardb.com/heroku_97681db3eff7580?reconnect=true'
         url = dj_database_url.parse(url)


### PR DESCRIPTION
I added a location for the pure python based mysql connector: http://dev.mysql.com/doc/connector-python/en/connector-python-django-backend.html

I'm not overly fond of the long schema name, but I couldn't think of anything better, if you want me to change anything, let me know.