### PR TITLE
Fallback to 'default' database config

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import inspect
 
 try:
     import urlparse
@@ -37,6 +38,12 @@ SCHEMES = {
 
 def config(env=DEFAULT_ENV, default=None, engine=None):
     """Returns configured DATABASE dictionary from DATABASE_URL."""
+
+    if default is None:
+        callers_source_filename = inspect.stack()[1][1]
+        base_dir = os.path.dirname(os.path.dirname(callers_source_filename))
+        db_filename = os.path.join(base_dir, 'db.sqlite3')
+        default = "sqlite:///{db_filename}".format(db_filename=db_filename)
 
     config = {}
 

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -68,10 +68,6 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PORT'] == ''
 
     def test_database_url(self):
-        del os.environ['DATABASE_URL']
-        a = dj_database_url.config()
-        assert not a
-
         os.environ['DATABASE_URL'] = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
 
         url = dj_database_url.config()
@@ -82,6 +78,15 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['USER'] == 'uf07k1i6d8ia0v'
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 5431
+
+    def test_database_url_fallsback_to_default(self):
+        del os.environ['DATABASE_URL']
+        url = dj_database_url.config()
+
+        # assert config matches the 'default' settings.py database
+        assert url['ENGINE'] == 'django.db.backends.sqlite3'
+        assert url['NAME'] == os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                           'db.sqlite3')
 
     def test_empty_sqlite_url(self):
         url = 'sqlite://'


### PR DESCRIPTION
The motivation for this change is that I've often found myself starting a Django project and then immediately wanting to get it set up to use the wonderful flexibility provided by `dj-database-url` (thank you for this project!).  However I always have to then lookup the value for `default` that has the same behavior as the default specification provided by the `django-admin.py` tool when creating a project.  I'd guess others have to jump through this same hoop, so this change seeks to make things easier.

This change only affects things in situations where neither a `DATABASE_URL` environment variable is provided nor does the user specify a `default` parameter.  Currently this just returns an empty dictionary, which doesn't appear to be useful. In a situation like this, I'd find it more convenient for `dj_database_url` to construct a database specification that matches the default database specification found in `settings.py` as created by the `django-admin.py startproject` command.

Here's the default database specification:
```
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.sqlite3',
        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
    }
}
```

Currently to maintain this behavior in the absence of a `DATABASE_URL` environment variable, a user must remember (or lookup) this incantation:
```
import dj_database_url
DATABASES = {
    'default': dj_database_url.config(default="sqlite:///%s" % os.path.join(BASE_DIR, 'db.sqlite3'))
}
```

With this proposed change, the specification can be simplified to:
```
import dj_database_url
DATABASES = {
    'default': dj_database_url.config()
}
```

Hopefully others will find such a change welcome.  The contributors to this project have my sincere thanks regardless!