### PR TITLE
Handle search path config in connect url for postgres

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -66,9 +66,13 @@ def parse(url, engine=None):
 
     url = urlparse.urlparse(url)
 
-    # Remove query strings.
+    # Split query strings from path.
     path = url.path[1:]
-    path = path.split('?', 2)[0]
+    if '?' in path and not url.query:
+        path, query = path.split('?', 2)
+    else:
+        path, query = path, url.query
+    query = urlparse.parse_qs(query)
 
     # If we are using sqlite and we have no path, then assume we
     # want an in-memory database (this is the behaviour of sqlalchemy)
@@ -93,5 +97,15 @@ def parse(url, engine=None):
         config['ENGINE'] = engine
     elif url.scheme in SCHEMES:
         config['ENGINE'] = SCHEMES[url.scheme]
+
+    if config['ENGINE'] == 'django.db.backends.postgresql_psycopg2':
+        try:
+            current_schema = query['currentSchema'][0]
+        except (KeyError, IndexError):
+            pass
+        else:
+            config['OPTIONS'] = {
+                'options': '-c search_path=' + current_schema
+            }
 
     return config

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -34,6 +34,17 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == ''
         assert url['PORT'] == ''
 
+    def test_postgres_search_path_parsing(self):
+        url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema'
+        url = dj_database_url.parse(url)
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == 5431
+        assert url['OPTIONS'] == {'options': '-c search_path=otherschema'}
+
     def test_postgis_parsing(self):
         url = 'postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py{26,27,32,33,34}
+
+
+[testenv]
+commands = python test_dj_database_url.py


### PR DESCRIPTION
Hi,

PostgreSQL supports an additional layer underneath Databases called named Schema. This Pull Request adds support to specify which schema should be used by Django if specified and omits the ``OPTIONS`` key entirely otherwise. It works like the ``currentSchema`` option as documented [here](https://jdbc.postgresql.org/documentation/head/connect.html).