### PR TITLE
Enable CA providing for MySQL URIs

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -105,6 +105,10 @@ def parse(url, engine=None, conn_max_age=0):
     # Pass the query string into OPTIONS.
     options = {}
     for key, values in query.items():
+        if url.scheme == 'mysql' and key == 'ssl-ca':
+            options['ssl'] = {'ca': values[-1]}
+            continue
+
         options[key] = values[-1]
 
     # Support for Postgres Schema URLs

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -180,6 +180,26 @@ class DatabaseTestSuite(unittest.TestCase):
         url = dj_database_url.config()
         assert 'OPTIONS' not in url
 
+    def test_mysql_database_url_with_sslca_options(self):
+        os.environ['DATABASE_URL'] = 'mysql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn?ssl-ca=rds-combined-ca-bundle.pem'
+        url = dj_database_url.config()
+
+        assert url['ENGINE'] == 'django.db.backends.mysql'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == 3306
+        assert url['OPTIONS'] == {
+            'ssl': {
+                    'ca': 'rds-combined-ca-bundle.pem'
+            }
+        }
+
+        # Test empty options
+        os.environ['DATABASE_URL'] = 'mysql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:3306/d8r82722r2kuvn?'
+        url = dj_database_url.config()
+        assert 'OPTIONS' not in url
 
     def test_oracle_parsing(self):
         url = 'oracle://scott:tiger@oraclehost:1521/hr'


### PR DESCRIPTION
Using `ssl-ca` from the command line as parameter to provide the CA.
Django MySQL database configuration uses a nested dictionary:

```
{'options': {
     'ssl': {
         'ca': 'PATH TO CA'
     }
 }
```