### PR TITLE
Fixes issue with unix file paths being turned to lower case

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -85,7 +85,12 @@ def parse(url, engine=None, conn_max_age=0):
         path = ':memory:'
 
     # Handle postgres percent-encoded paths.
-    hostname = url.hostname or ''
+    netloc = url.netloc
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[1]
+    if ":" in netloc:
+        netloc = netloc.split(":", 1)[0]
+    hostname = netloc or ''
     if '%2f' in hostname.lower():
         hostname = hostname.replace('%2f', '/').replace('%2F', '/')
 

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -34,6 +34,15 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == ''
         assert url['PORT'] == ''
 
+        url = 'postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['HOST'] == '/Users/postgres/RuN'
+        assert url['USER'] == ''
+        assert url['PASSWORD'] == ''
+        assert url['PORT'] == ''
+
     def test_postgres_search_path_parsing(self):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema'
         url = dj_database_url.parse(url)


### PR DESCRIPTION
The main issue I'm having is on my development box (a mac) i want to have the freedom to place the socket file anywhere i want, and out of laziness its usually inside `~/`. This means its going to look like `/Users/buzzi/Projects/...` you get the point. When dj-database-url references `urlparse.urlparse(..)` it turns the `hostname` into lowercase and voila! it breaks my paths.

Please review and discuss.
