### PR TITLE
Fix IPv6 address parsing

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -87,13 +87,14 @@ def parse(url, engine=None, conn_max_age=0):
         path = ':memory:'
 
     # Handle postgres percent-encoded paths.
-    netloc = url.netloc
-    if "@" in netloc:
-        netloc = netloc.rsplit("@", 1)[1]
-    if ":" in netloc:
-        netloc = netloc.split(":", 1)[0]
-    hostname = netloc or ''
+    hostname = url.hostname or ''
     if '%2f' in hostname.lower():
+        # Switch to url.netloc to avoid lower cased paths
+        hostname = url.netloc
+        if "@" in hostname:
+            hostname = hostname.rsplit("@", 1)[1]
+        if ":" in hostname:
+            hostname = hostname.split(":", 1)[0]
         hostname = hostname.replace('%2f', '/').replace('%2F', '/')
 
     # Update with environment configuration.

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -43,6 +43,17 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == ''
         assert url['PORT'] == ''
 
+    def test_ipv6_parsing(self):
+        url = 'postgres://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == '2001:db8:1234::1234:5678:90af'
+        assert url['USER'] == 'ieRaekei9wilaim7'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == 5431
+
     def test_postgres_search_path_parsing(self):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema'
         url = dj_database_url.parse(url)


### PR DESCRIPTION
Sadly IPv6 address parsing was broken by 8974da0191046fdfa71d6f695076b83fa7f63fbf and released in 0.4.2.

This should only switch to using/parsing url.netloc for file paths if there's a %2f (a /) in the hostname.