### PR TITLE
Django expects Oracle Ports as strings

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -97,18 +97,21 @@ def parse(url, engine=None, conn_max_age=0):
             hostname = hostname.split(":", 1)[0]
         hostname = hostname.replace('%2f', '/').replace('%2F', '/')
 
+    # Lookup specified engine.
+    engine = SCHEMES[url.scheme] if engine is None else engine
+
+    port = (str(url.port) if url.port and engine == SCHEMES['oracle']
+            else url.port)
+
     # Update with environment configuration.
     config.update({
         'NAME': urlparse.unquote(path or ''),
         'USER': urlparse.unquote(url.username or ''),
         'PASSWORD': urlparse.unquote(url.password or ''),
         'HOST': hostname,
-        'PORT': url.port or '',
+        'PORT': port or '',
         'CONN_MAX_AGE': conn_max_age,
     })
-
-    # Lookup specified engine.
-    engine = SCHEMES[url.scheme] if engine is None else engine
 
     # Pass the query string into OPTIONS.
     options = {}

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -242,7 +242,7 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['HOST'] == 'oraclehost'
         assert url['USER'] == 'scott'
         assert url['PASSWORD'] == 'tiger'
-        assert url['PORT'] == 1521
+        assert url['PORT'] == '1521'
 
     def test_oracle_gis_parsing(self):
         url = 'oraclegis://scott:tiger@oraclehost:1521/hr'


### PR DESCRIPTION
Oracle stuff It's kind of poorly documented however here we have  a pair of [examples](https://docs.djangoproject.com/en/1.10/ref/databases/#id13).


