### PR TITLE
use str port for mssql

### DIFF
--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -102,7 +102,7 @@ def parse(url, engine=None, conn_max_age=0):
     # Lookup specified engine.
     engine = SCHEMES[url.scheme] if engine is None else engine
 
-    port = (str(url.port) if url.port and engine == SCHEMES['oracle']
+    port = (str(url.port) if url.port and engine in [SCHEMES['oracle'], SCHEMES['mssql']]
             else url.port)
 
     # Update with environment configuration.

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -315,6 +315,19 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['OPTIONS']['driver'] == 'ODBC Driver 13 for SQL Server'
         assert 'currentSchema' not in url['OPTIONS']
 
+    def test_mssql_instance_port_parsing(self):
+        url = 'mssql://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com\\insnsnss:12345/d8r82722r2kuvn?driver=ODBC Driver 13 for SQL Server'
+        url = dj_database_url.parse(url)
+
+        assert url['ENGINE'] == 'sql_server.pyodbc'
+        assert url['NAME'] == 'd8r82722r2kuvn'
+        assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com\\insnsnss'
+        assert url['USER'] == 'uf07k1i6d8ia0v'
+        assert url['PASSWORD'] == 'wegauwhgeuioweg'
+        assert url['PORT'] == '12345'
+        assert url['OPTIONS']['driver'] == 'ODBC Driver 13 for SQL Server'
+        assert 'currentSchema' not in url['OPTIONS']
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
this was a bug in my original implementation. 

the mssql adapter loves ports served as a string - same as oracle.

