### PR TITLE
fix #96 deprecated postgres backend strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,36 @@ python:
   - 3.4
   - 3.5
   - 3.6
+
+env:
+  matrix:
+   - DJANGO="Django>=1.8,<1.9"
+   - DJANGO="Django>=1.9,<1.10"
+   - DJANGO="Django>=1.10,<1.11"
+   - DJANGO="Django>=1.11,<2.0"
+   - DJANGO="Django>=2.0,<2.1"
+   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.3
+      env: DJANGO="Django>=1.8,<1.9"
+  exclude:
+    # Django 2 dropped support for Python 2.
+    - python: 2.7
+      env: DJANGO="Django>=2.0,<2.1"
+    - python: 2.7
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    # Django master dropped support for Python < 3.5.
+    - python: 3.2
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    - python: 3.3
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+    - python: 3.4
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+
+install: pip install . $DJANGO
 script: make test

--- a/dj_database_url.py
+++ b/dj_database_url.py
@@ -7,6 +7,11 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
+try:
+    from django import VERSION as DJANGO_VERSION
+except ImportError:
+    DJANGO_VERSION = None
+
 
 # Register database schemes in URLs.
 urlparse.uses_netloc.append('postgres')
@@ -27,9 +32,6 @@ urlparse.uses_netloc.append('redshift')
 DEFAULT_ENV = 'DATABASE_URL'
 
 SCHEMES = {
-    'postgres': 'django.db.backends.postgresql_psycopg2',
-    'postgresql': 'django.db.backends.postgresql_psycopg2',
-    'pgsql': 'django.db.backends.postgresql_psycopg2',
     'postgis': 'django.contrib.gis.db.backends.postgis',
     'mysql': 'django.db.backends.mysql',
     'mysql2': 'django.db.backends.mysql',
@@ -42,6 +44,16 @@ SCHEMES = {
     'oraclegis': 'django.contrib.gis.db.backends.oracle',
     'redshift': 'django_redshift_backend',
 }
+
+# https://docs.djangoproject.com/en/2.0/releases/2.0/#id1
+if DJANGO_VERSION and DJANGO_VERSION < (2, 0):
+    SCHEMES['postgres'] = 'django.db.backends.postgresql_psycopg2'
+    SCHEMES['postgresql'] = 'django.db.backends.postgresql_psycopg2'
+    SCHEMES['pgsql'] = 'django.db.backends.postgresql_psycopg2'
+else:
+    SCHEMES['postgres'] = 'django.db.backends.postgresql'
+    SCHEMES['postgresql'] = 'django.db.backends.postgresql'
+    SCHEMES['pgsql'] = 'django.db.backends.postgresql'
 
 
 def config(env=DEFAULT_ENV, default=None, engine=None, conn_max_age=0, ssl_require=False):
@@ -131,6 +143,7 @@ def parse(url, engine=None, conn_max_age=0, ssl_require=False):
     if 'currentSchema' in options and engine in (
         'django.contrib.gis.db.backends.postgis',
         'django.db.backends.postgresql_psycopg2',
+        'django.db.backends.postgresql',
         'django_redshift_backend',
     ):
         options['options'] = '-c search_path={0}'.format(options.pop('currentSchema'))

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -4,6 +4,8 @@
 import os
 import unittest
 
+from django import VERSION as DJANGO_VERSION
+
 import dj_database_url
 
 
@@ -16,7 +18,10 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -27,7 +32,10 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == '/var/run/postgresql'
         assert url['USER'] == ''
@@ -37,7 +45,10 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['HOST'] == '/Users/postgres/RuN'
         assert url['USER'] == ''
         assert url['PASSWORD'] == ''
@@ -47,7 +58,10 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == '2001:db8:1234::1234:5678:90af'
         assert url['USER'] == 'ieRaekei9wilaim7'
@@ -57,7 +71,10 @@ class DatabaseTestSuite(unittest.TestCase):
     def test_postgres_search_path_parsing(self):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema'
         url = dj_database_url.parse(url)
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -70,7 +87,10 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database'
         url = dj_database_url.parse(url)
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == '#database'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == '#user'
@@ -142,7 +162,10 @@ class DatabaseTestSuite(unittest.TestCase):
 
         url = dj_database_url.config()
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -196,7 +219,10 @@ class DatabaseTestSuite(unittest.TestCase):
         os.environ['DATABASE_URL'] = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full'
         url = dj_database_url.config()
 
-        assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        if DJANGO_VERSION < (2, 0):
+            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
+        else:
+            assert url['ENGINE'] == 'django.db.backends.postgresql'
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'

--- a/test_dj_database_url.py
+++ b/test_dj_database_url.py
@@ -11,6 +11,12 @@ import dj_database_url
 
 POSTGIS_URL = 'postgis://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
 
+# Django deprecated the `django.db.backends.postgresql_psycopg2` in 2.0.
+# https://docs.djangoproject.com/en/2.0/releases/2.0/#id1
+EXPECTED_POSTGRES_ENGINE = 'django.db.backends.postgresql'
+if DJANGO_VERSION < (2, 0):
+    EXPECTED_POSTGRES_ENGINE = 'django.db.backends.postgresql_psycopg2'
+
 
 class DatabaseTestSuite(unittest.TestCase):
 
@@ -18,10 +24,7 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -32,10 +35,7 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%2Fvar%2Frun%2Fpostgresql/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == '/var/run/postgresql'
         assert url['USER'] == ''
@@ -45,10 +45,7 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%2FUsers%2Fpostgres%2FRuN/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['HOST'] == '/Users/postgres/RuN'
         assert url['USER'] == ''
         assert url['PASSWORD'] == ''
@@ -58,10 +55,7 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://ieRaekei9wilaim7:wegauwhgeuioweg@[2001:db8:1234::1234:5678:90af]:5431/d8r82722r2kuvn'
         url = dj_database_url.parse(url)
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == '2001:db8:1234::1234:5678:90af'
         assert url['USER'] == 'ieRaekei9wilaim7'
@@ -71,10 +65,7 @@ class DatabaseTestSuite(unittest.TestCase):
     def test_postgres_search_path_parsing(self):
         url = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?currentSchema=otherschema'
         url = dj_database_url.parse(url)
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -87,10 +78,7 @@ class DatabaseTestSuite(unittest.TestCase):
         url = 'postgres://%23user:%23password@ec2-107-21-253-135.compute-1.amazonaws.com:5431/%23database'
         url = dj_database_url.parse(url)
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == '#database'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == '#user'
@@ -162,10 +150,7 @@ class DatabaseTestSuite(unittest.TestCase):
 
         url = dj_database_url.config()
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'
@@ -219,10 +204,7 @@ class DatabaseTestSuite(unittest.TestCase):
         os.environ['DATABASE_URL'] = 'postgres://uf07k1i6d8ia0v:wegauwhgeuioweg@ec2-107-21-253-135.compute-1.amazonaws.com:5431/d8r82722r2kuvn?sslrootcert=rds-combined-ca-bundle.pem&sslmode=verify-full'
         url = dj_database_url.config()
 
-        if DJANGO_VERSION < (2, 0):
-            assert url['ENGINE'] == 'django.db.backends.postgresql_psycopg2'
-        else:
-            assert url['ENGINE'] == 'django.db.backends.postgresql'
+        assert url['ENGINE'] == EXPECTED_POSTGRES_ENGINE
         assert url['NAME'] == 'd8r82722r2kuvn'
         assert url['HOST'] == 'ec2-107-21-253-135.compute-1.amazonaws.com'
         assert url['USER'] == 'uf07k1i6d8ia0v'


### PR DESCRIPTION
The database backend "django.db.backends.postgresql_psycopg2" has been deprecated
in Django 2.0 in favor of "django.db.backends.postgresql".

https://docs.djangoproject.com/en/2.0/releases/2.0/#id1